### PR TITLE
fix success event fired too early

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -215,9 +215,6 @@
       }
     }
     this.isValid = true;
-    if (this.success) {
-      this.success();
-    }
     return this;
   };
 


### PR DESCRIPTION
The success event has been fired twice:
- when resource listing has been consumed
- when operations has been consumed

The fix removes to fire the event once the resource listing has been consumed.

@kiebzak 