### PR TITLE
fix path param encoding

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -939,22 +939,6 @@
     return this.path.replace("{format}", "xml");
   };
 
-  SwaggerOperation.prototype.encodePathParam = function (pathParam) {
-    var encParts, part, parts, _i, _len;
-    pathParam = pathParam.toString();
-    if (pathParam.indexOf("/") === -1) {
-      return encodeURIComponent(pathParam);
-    } else {
-      parts = pathParam.split("/");
-      encParts = [];
-      for (_i = 0, _len = parts.length; _i < _len; _i++) {
-        part = parts[_i];
-        encParts.push(encodeURIComponent(part));
-      }
-      return encParts.join("/");
-    }
-  };
-
   SwaggerOperation.prototype.urlify = function (args) {
     var url = this.resource.basePath + this.pathJson();
     var params = this.parameters;
@@ -987,7 +971,7 @@
           }
           var paramEnd = findParamEnd(paramStart,url);
           if(paramStart>=0){
-              url = url.substring(0,paramStart)+this.encodePathParam(args[param.name]) + url.substring(paramEnd);
+              url = url.substring(0,paramStart)+encodeURIComponent(args[param.name]) + url.substring(paramEnd);
           }
           delete args[param.name];
         }


### PR DESCRIPTION
The path param that contained / has been split base on / character and each segment has been encoded, which caused that to change the path.

The fix is to encode the / as part of the path parameter.